### PR TITLE
Fix/mobile tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           key: v1-npmcache-{{ checksum "wp-e2e-tests/.nvmrc" }}-{{ checksum "wp-e2e-tests/package-lock.json" }}
           paths:
             - "~/.npm"
-      #- run: sudo apt install -y ffmpeg
+      - run: sudo apt install -y ffmpeg
       - run: sudo chmod +x wp-e2e-tests/node_modules/.bin/magellan
       - run: cd wp-e2e-tests && npm run decryptconfig && ./run.sh -R -W $RUN_ARGS
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           key: v1-npmcache-{{ checksum "wp-e2e-tests/.nvmrc" }}-{{ checksum "wp-e2e-tests/package-lock.json" }}
           paths:
             - "~/.npm"
-      - run: sudo apt install -y ffmpeg
+      #- run: sudo apt install -y ffmpeg
       - run: sudo chmod +x wp-e2e-tests/node_modules/.bin/magellan
       - run: cd wp-e2e-tests && npm run decryptconfig && ./run.sh -R -W $RUN_ARGS
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           key: v1-npmcache-{{ checksum "wp-e2e-tests/.nvmrc" }}-{{ checksum "wp-e2e-tests/package-lock.json" }}
           paths:
             - "~/.npm"
+      - run: sudo apt install -y ffmpeg
       - run: sudo chmod +x wp-e2e-tests/node_modules/.bin/magellan
       - run: cd wp-e2e-tests && npm run decryptconfig && ./run.sh -R -W $RUN_ARGS
       - store_test_results:


### PR DESCRIPTION
Adding installation of ffmpeg so we can turn on video recording for these tests.

This also fixes https://github.com/Automattic/wp-e2e-tests/issues/1500 since having the browsers open in separate displays, the way it is done for video recording, keeps the issue from happening. 